### PR TITLE
docker secret update

### DIFF
--- a/docker-secret.yaml
+++ b/docker-secret.yaml
@@ -9,5 +9,5 @@ data:
   # Use 'ibmcloud cr token-add --description "<description>" --non-expiring -q' to generate token
   # Use 'echo -n "token" | base64' to generate this string
   username: dG9rZW4=
-  # Use 'echo -n "<token_value>" | base64 -w0' to generate this string
+  # Use 'echo -n "<token_value>" | base64' to generate this string
   password: <base_64_encoded_token_value>


### PR DESCRIPTION
@duglin -w0 is not a valid option for base64 encode command on a mac.